### PR TITLE
FEATURE(oio-event-agent): Add oio-event-delete service

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ An Ansible role for oio-event-agent. Specifically, the responsibilities of this 
 | `openio_event_agent_location` | `"{{ ansible_hostname }}.{{ openio_event_agent_serviceid }}"` | Location |
 | `openio_event_agent_namespace` | `"OPENIO"` | Namespace |
 | `openio_event_agent_provision_only` | `false` | Provision only without restarting services |
+| `openio_event_agent_tube_delete_enabled` | `false` | Deploy a dedicated agent to process delete events |
 | `openio_event_agent_queue_url` | `"beanstalk://{{ ansible_default_ipv4.address }}:6014"` | URL of queue service |
 | `openio_event_agent_serviceid` | `"0"` | ID in gridinit |
 | `openio_event_agent_storage_chunk_deleted_pipeline` | `list` | List of middlewares involved in `storage.chunk.deleted` |
@@ -43,8 +44,11 @@ An Ansible role for oio-event-agent. Specifically, the responsibilities of this 
 | `openio_event_agent_storage_content_drained_pipeline` | `list` | List of middlewares involved in `storage.content.drained` |
 | `openio_event_agent_storage_content_update_pipeline` | `list` | List of middlewares involved in `storage.content.update` |
 | `openio_event_agent_storage_content_perfectible_pipeline` | `[]` | List of middlewares involved in `storage.content.perfectible` |
+| `openio_event_agent_storage_content_notify_delete_pipeline` | `[]` | List of middlewares involved in `storage.content.deleted` with separate delete queue |
 | `openio_event_agent_tube` | `oio` | Tube used in queue service |
 | `openio_event_agent_workers` | `"{{ ansible_processor_vcpus / 2 }}"` | Number of workers  |
+| `openio_event_agent_delete_workers` | `"1"` | Number of workers of the event delete agent  |
+| `openio_event_agent_delete_concurrency` | `"1"` | Concurrency of the event delete agent  |
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,11 +9,17 @@ openio_event_agent_gridinit_file_prefix: ""
 openio_event_agent_workers: "{{ ansible_processor_vcpus / 2 | int }}"
 openio_event_agent_concurrency: ""
 
+openio_event_agent_delete_workers: "1"
+openio_event_agent_delete_concurrency: "1"
+
 openio_event_agent_queue_url: "beanstalk://{{ ansible_default_ipv4.address }}:6014"
 openio_event_agent_tube: oio
 
+
 openio_event_agent_provision_only: false
 openio_event_agent_location: "{{ ansible_hostname }}.{{ openio_event_agent_serviceid }}"
+
+openio_event_agent_tube_delete_enabled: false
 
 # pipelines
 openio_event_agent_storage_content_new_pipeline:
@@ -33,6 +39,9 @@ openio_event_agent_storage_content_drained_pipeline:
 
 openio_event_agent_storage_content_deleted_pipeline:
   - content_cleaner
+
+openio_event_agent_storage_content_notify_delete_pipeline:
+  - notify_delete
 
 openio_event_agent_storage_container_new_pipeline:
   - account_update
@@ -91,6 +100,11 @@ openio_event_agent_filter_replication:
 openio_event_agent_filter_content_improve:
   use: "egg:oio#notify"
   tube: "oio-improve"
+  queue_url: "{{ openio_event_agent_queue_url }}"
+
+openio_event_agent_filter_notify_delete:
+  use: "egg:oio#notify"
+  tube: "oio-delete"
   queue_url: "{{ openio_event_agent_queue_url }}"
 
 openio_event_agent_filter_wildcard: {}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -48,12 +48,39 @@
         {{ openio_event_agent_servicename }}.conf"
   register: _event_agent_conf
 
+- name: "Generate configuration files (event delete)"
+  template:
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+    owner: openio
+    group: openio
+    mode: 0644
+  with_items:
+    - src: "event_delete.conf.j2"
+      dest: "{{ openio_event_agent_sysconfig_dir }}/\
+        {{ openio_event_agent_servicename }}/{{ openio_event_delete_servicename }}.conf"
+    - src: "event_delete_handlers.conf.j2"
+      dest: "{{ openio_event_agent_sysconfig_dir }}/\
+        {{ openio_event_agent_servicename }}/oio-event-handlers-delete.conf"
+    - src: "gridinit_event_delete.conf.j2"
+      dest: "{{ openio_event_agent_gridinit_dir }}/{{ openio_event_agent_gridinit_file_prefix }}\
+        {{ openio_event_delete_servicename }}.conf"
+  register: _event_delete_conf
+  when: openio_event_agent_tube_delete_enabled
+
+- name: "Ensure proper state for gridinit service"
+  file:
+    name: "{{ openio_event_agent_gridinit_dir }}/{{ openio_event_agent_gridinit_file_prefix }}\
+      {{ openio_event_delete_servicename }}.conf"
+    state: "{{ 'file' if openio_event_agent_tube_delete_enabled else 'absent' }}"
+  register: _event_delete_conf
+
 - name: restart event_agent
   shell: |
     gridinit_cmd reload
     gridinit_cmd restart  {{ openio_event_agent_namespace }}-{{ openio_event_agent_servicename }}
   when:
-    - _event_agent_conf.changed
+    - _event_agent_conf.changed or _event_delete_conf.changed
     - not openio_event_agent_provision_only
   tags: configure
 ...

--- a/templates/event_agent_handlers.conf.j2
+++ b/templates/event_agent_handlers.conf.j2
@@ -16,7 +16,11 @@ pipeline = {{ openio_event_agent_storage_content_update_pipeline | join(' ') }}
 pipeline = {{ openio_event_agent_storage_content_drained_pipeline | join(' ') }}
 
 [handler:storage.content.deleted]
+{% if openio_event_agent_tube_delete_enabled %}
+pipeline = {{ openio_event_agent_storage_content_notify_delete_pipeline | join(' ') }}
+{% else %}
 pipeline = {{ openio_event_agent_storage_content_deleted_pipeline | join(' ') }}
+{% endif %}
 
 [handler:storage.content.perfectible]
 pipeline = {{ openio_event_agent_storage_content_perfectible_pipeline | join(' ') }}
@@ -45,6 +49,7 @@ pipeline = {{ openio_event_agent_account_service_pipeline | join(' ') }}
                        + openio_event_agent_storage_content_update_pipeline
                        + openio_event_agent_storage_content_drained_pipeline
                        + openio_event_agent_storage_content_deleted_pipeline
+                       + openio_event_agent_storage_content_notify_delete_pipeline
                        + openio_event_agent_storage_container_new_pipeline
                        + openio_event_agent_storage_container_deleted_pipeline
                        + openio_event_agent_storage_container_state_pipeline
@@ -53,6 +58,15 @@ pipeline = {{ openio_event_agent_account_service_pipeline | join(' ') }}
                        + openio_event_agent_storage_content_perfectible_pipeline
                        + openio_event_agent_account_service_pipeline %}
 ### filters
+{% if openio_event_agent_tube_delete_enabled %}
+{% if 'notify_delete' in pipeline_merged %}
+[filter:notify_delete]
+{% for k, v in openio_event_agent_filter_notify_delete.iteritems() %}
+{{ k }} = {{ v }}
+{% endfor %}
+{% endif %}
+{% endif %}
+
 {% if 'noop' in pipeline_merged %}
 [filter:noop]
 {% for k, v in openio_event_agent_filter_noop.iteritems() %}

--- a/templates/event_delete.conf.j2
+++ b/templates/event_delete.conf.j2
@@ -1,0 +1,14 @@
+# {{ ansible_managed }}
+[event-agent]
+tube = oio-delete
+namespace = {{ openio_event_agent_namespace }}
+user = openio
+queue_url = {{ openio_event_agent_queue_url }}
+workers = {{ openio_event_agent_delete_workers }}
+concurrency = {{ openio_event_agent_delete_concurrency }}
+handlers_conf = /etc/oio/sds/{{ openio_event_agent_namespace }}/{{ openio_event_agent_servicename }}/oio-event-handlers-delete.conf
+log_facility = LOG_LOCAL0
+log_level = info
+log_name = {{ openio_event_delete_servicename }}
+log_address = /dev/log
+syslog_prefix = OIO,{{ openio_event_agent_namespace }},oio-event-agent,{{ openio_event_agent_serviceid }}

--- a/templates/event_delete_handlers.conf.j2
+++ b/templates/event_delete_handlers.conf.j2
@@ -1,0 +1,6 @@
+# {{ ansible_managed }}
+[handler:storage.content.deleted]
+pipeline = content_cleaner
+
+[filter:content_cleaner]
+use = egg:oio#content_cleaner

--- a/templates/gridinit_event_delete.conf.j2
+++ b/templates/gridinit_event_delete.conf.j2
@@ -1,0 +1,10 @@
+# {{ ansible_managed }}
+[Service.{{ openio_event_agent_namespace }}-{{ openio_event_delete_servicename }}]
+command=/usr/bin/oio-event-agent /etc/oio/sds/{{ openio_event_agent_namespace }}/oio-event-agent-{{ openio_event_agent_serviceid }}/{{ openio_event_delete_servicename }}.conf
+enabled=true
+start_at_boot=true
+on_die=respawn
+group={{ openio_event_agent_namespace }},oio-event-agent,{{ openio_event_agent_serviceid }}
+uid=openio
+gid=openio
+env.PATH=/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,9 +1,9 @@
 ---
 openio_event_agent_sysconfig_dir: "/etc/oio/sds/{{ openio_event_agent_namespace }}"
 openio_event_agent_servicename: "oio-event-agent-{{ openio_event_agent_serviceid }}"
+openio_event_delete_servicename: "{{ openio_event_agent_servicename }}.1"
 
 openio_event_agent_definition_file: >
   "{{ openio_event_agent_sysconfig_dir }}/
   {{ openio_event_agent_servicename }}/{{ openio_event_agent_servicename }}.conf"
-
 ...


### PR DESCRIPTION
 ##### ISSUE TYPE
- Feature

 ##### SUMMARY
Add new queue oio-delete, and process it using a separate service
oio-event-delete. This allows to control the rate at which delete events
are processed and prevents high loads on a platform when a mass delete
has been ordered.

It can be enabled simply by flipping `openio_event_agent_tube_delete_enabled`

 ##### IMPACT

N/A

 ##### ADDITIONAL INFORMATION

CI Docker tests have been updated to test using this new configuration.

 ##### MIGRATION NOTES

Future releases should enable this parameter by default