### PR TITLE
BUGFIX/MEDIUM(event-agent): Fix _event_delete_conf in dryrun mode

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -74,6 +74,7 @@
       {{ openio_event_delete_servicename }}.conf"
     state: "{{ 'file' if openio_event_agent_tube_delete_enabled else 'absent' }}"
   register: _event_delete_conf
+  ignore_errors: "{{ ansible_check_mode }}"
 
 - name: reload gridinit config
   command: gridinit_cmd reload


### PR DESCRIPTION
 ##### SUMMARY
Currently, the dryrun mode is not OK
```yaml
TASK [oio-event-agent : Ensure proper state for gridinit service] **************
Wednesday 13 March 2019  15:44:53 +0000 (0:00:00.252)       0:07:26.079 *******
[0;31mfatal: [node2]: FAILED! => changed=false [0m
[0;31m  msg: file (/etc/gridinit.d//OPENIO-oio-event-agent-0.1.conf) is absent, cannot continue[0m
[0;31m  path: /etc/gridinit.d//OPENIO-oio-event-agent-0.1.conf[0m
[0;31m  state: absent[0m
[0;31mfatal: [node3]: FAILED! => changed=false [0m
[0;31m  msg: file (/etc/gridinit.d//OPENIO-oio-event-agent-0.1.conf) is absent, cannot continue[0m
[0;31m  path: /etc/gridinit.d//OPENIO-oio-event-agent-0.1.conf[0m
[0;31m  state: absent[0m
[0;31mfatal: [node4]: FAILED! => changed=false [0m
[0;31m  msg: file (/etc/gridinit.d//OPENIO-oio-event-agent-0.1.conf) is absent, cannot continue[0m
[0;31m  path: /etc/gridinit.d//OPENIO-oio-event-agent-0.1.conf[0m
[0;31m  state: absent[0m
```

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION