### PR TITLE
CHANGE(event_agent): Ensure service is started or restarted at the en…

### DIFF
--- a/docker-tests/test.yml
+++ b/docker-tests/test.yml
@@ -4,18 +4,17 @@
   become: true
   vars:
     NS: TRAVIS
+    openio_bootstrap: true
   roles:
     - role: users
     - role: repo
       openio_repository_no_log: false
-      openio_repository_products:
-        sds:
-          release: "18.10"
-    - role: namespace
-      openio_namespace_name: "{{ NS }}"
+      openio_repository_mirror_host: mirror2.openio.io
     - role: gridinit
       openio_gridinit_namespace: "{{ NS }}"
       openio_gridinit_per_ns: true
+    - role: namespace
+      openio_namespace_name: "{{ NS }}"
     - role: role_under_test
       openio_event_agent_tube_delete_enabled: true
       openio_event_agent_namespace: "{{ NS }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -82,17 +82,40 @@
     - _event_agent_conf.changed or _event_delete_conf.changed
     - not openio_event_agent_provision_only
 
-- name: restart event_agent
+- name: "restart event_agent to apply the new configuration"
   command: gridinit_cmd restart {{ openio_event_agent_namespace }}-{{ openio_event_agent_servicename }}
+  register: _restart_event_agent
   when:
-    - _event_agent_conf.changed
+    - _event_agent_conf is changed
     - not openio_event_agent_provision_only
   tags: configure
 
-- name: restart event_delete
+- name: "restart event_delete to apply the new configuration"
   command: gridinit_cmd restart {{ openio_event_agent_namespace }}-{{ openio_event_delete_servicename }}
+  register: _restart_event_delete
   when:
-    - _event_delete_conf.changed
+    - _event_delete_conf is changed
     - not openio_event_agent_provision_only
   tags: configure
+
+- block:
+    - name: "Ensure event_agent is started"
+      command: gridinit_cmd start {{ openio_event_agent_namespace }}-{{ openio_event_agent_servicename }}
+      register: _start_event_agent
+      changed_when: '"Success" in _start_event_agent.stdout'
+      when:
+        - not openio_event_agent_provision_only
+        - _restart_event_agent is skipped
+      tags: configure
+
+    - name: "Ensure event_delete is started"
+      command: gridinit_cmd start {{ openio_event_agent_namespace }}-{{ openio_event_delete_servicename }}
+      register: _start_event_delete
+      changed_when: '"Success" in _start_event_delete.stdout'
+      when:
+        - not openio_event_agent_provision_only
+        - _restart_event_delete is skipped
+      tags: configure
+
+  when: openio_bootstrap | d(false)
 ...


### PR DESCRIPTION
…d of role

 ##### SUMMARY
Until 18.10, a voluntarily stopped service was not revived by a reproviosionning.

In 19.04, the `maintenance` mode becomes the default mode.

To avoid having to force (ie. deletion of conf files) the restart of a service delivered first, by error, in maintenance mode: We have to make sure that service is started and it works well at the end of the role.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION