### PR TITLE
BUGFIX/MEDIUM(oio-event-agent): Prevent 0 workers in event agent 

### DIFF
--- a/templates/event_agent.conf.j2
+++ b/templates/event_agent.conf.j2
@@ -4,7 +4,7 @@ namespace = {{ openio_event_agent_namespace }}
 user = openio
 tube = {{ openio_event_agent_tube }}
 queue_url = {{ openio_event_agent_queue_url }}
-{% if openio_event_agent_workers %}
+{% if (openio_event_agent_workers | int) > 0 %}
 workers = {{ openio_event_agent_workers | int }}
 {% endif %}
 {% if openio_event_agent_concurrency %}


### PR DESCRIPTION
 ##### SUMMARY

Currently (SDS 5.0.0.0b1), if a worker value is set in the event agent
it will always be used. This is an issue when the server has 1 CPU
(int(1/2) = 0 workers), meaning the event agent doesn't spawn any
workers. This workaround prevents this faulty behavior until it has been
properly fixed in the code.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION