### PR TITLE
CHANGE(oio-event-agent): Add flag to force package upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ An Ansible role for oio-event-agent. Specifically, the responsibilities of this 
 | `openio_event_agent_workers` | `"{{ ansible_processor_vcpus / 2 }}"` | Number of workers  |
 | `openio_event_agent_delete_workers` | `"1"` | Number of workers of the event delete agent  |
 | `openio_event_agent_delete_concurrency` | `"1"` | Concurrency of the event delete agent  |
+| `openio_event_agent_package_upgrade`       | `false` | Set the packages to the latest version (to be set in extra_vars) |
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,6 +16,7 @@ openio_event_agent_queue_url: "beanstalk://{{ openio_bind_address | d(ansible_de
 openio_event_agent_tube: oio
 
 openio_event_agent_provision_only: false
+openio_event_agent_package_upgrade: "{{ openio_package_upgrade | d(false) }}"
 openio_event_agent_location: "{{ ansible_hostname }}.{{ openio_event_agent_serviceid }}"
 
 openio_event_agent_tube_delete_enabled: true

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -2,7 +2,7 @@
 - name: Install packages
   package:
     name: "{{ pkg }}"
-    state: present
+    state: "{{ 'latest' if openio_event_agent_package_upgrade else 'present' }}"
   with_items: "{{ event_agent_packages }}"
   loop_control:
     loop_var: pkg

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -2,7 +2,7 @@
 - name: Install packages
   package:
     name: "{{ pkg }}"
-    state: present
+    state: "{{ 'latest' if openio_event_agent_package_upgrade else 'present' }}"
   with_items: "{{ event_agent_packages }}"
   loop_control:
     loop_var: pkg


### PR DESCRIPTION
 ##### SUMMARY

This is useful during upgrades, as it allows to update packages to the
latest version without requiring an external playbook/task.

To use this, simply provide the -e openio_package_upgrade=true argument

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION