### PR TITLE
FEATURE(oio-event-agent): Add a pipeline for `storage.meta2.deleted`

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -66,6 +66,9 @@ openio_event_agent_storage_chunk_new_pipeline:
 openio_event_agent_storage_chunk_deleted_pipeline:
   - volume_index
 
+openio_event_agent_storage_meta2_deleted_pipeline:
+  - volume_index
+
 openio_event_agent_account_service_pipeline:
   - account_update
   - volume_index

--- a/templates/event_agent_handlers.conf.j2
+++ b/templates/event_agent_handlers.conf.j2
@@ -25,6 +25,9 @@ pipeline = {{ openio_event_agent_storage_content_deleted_pipeline | join(' ') }}
 [handler:storage.content.perfectible]
 pipeline = {{ openio_event_agent_storage_content_perfectible_pipeline | join(' ') }}
 
+[handler:storage.meta2.deleted]
+pipeline = {{ openio_event_agent_storage_meta2_deleted_pipeline | join(' ') }}
+
 [handler:storage.container.new]
 pipeline = {{ openio_event_agent_storage_container_new_pipeline | join(' ') }}
 


### PR DESCRIPTION
 ##### SUMMARY

A new event is sent when the meta2 databases are deleted: storage.meta2.deleted: https://github.com/open-io/oio-sds/pull/1899

To avoid theses logs, we need to update event-handlers.conf

> no handler found for storage.meta2.deleted

```ini
[handler:storage.meta2.deleted]
pipeline = volume_index
```

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION
OS-447