### PR TITLE
FEATURE(event-agent): Add an instance for `xcute` events

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ An Ansible role for oio-event-agent. Specifically, the responsibilities of this 
 | `openio_event_agent_namespace` | `"OPENIO"` | Namespace |
 | `openio_event_agent_provision_only` | `false` | Provision only without restarting services |
 | `openio_event_agent_tube_delete_enabled` | `true` | Deploy a dedicated agent to process delete events |
+| `openio_event_agent_tube_xcute_enabled` | `true` | Deploy a dedicated agent to process xcute events |
 | `openio_event_agent_queue_url` | `"beanstalk://{{ ansible_default_ipv4.address }}:6014"` | URL of queue service |
 | `openio_event_agent_replicator_enabled` | `false` | Add filters for replicator |
 | `openio_event_agent_serviceid` | `"0"` | ID in gridinit |
@@ -50,6 +51,8 @@ An Ansible role for oio-event-agent. Specifically, the responsibilities of this 
 | `openio_event_agent_workers` | `"{{ ansible_processor_vcpus / 2 }}"` | Number of workers  |
 | `openio_event_agent_delete_workers` | `"1"` | Number of workers of the event delete agent  |
 | `openio_event_agent_delete_concurrency` | `"1"` | Concurrency of the event delete agent  |
+| `openio_event_agent_xcute_workers` | `"2"` | Number of workers of the event xcute agent  |
+| `openio_event_agent_xcute_concurrency` | `"5"` | Concurrency of the event xcute agent  |
 | `openio_event_agent_package_upgrade`       | `false` | Set the packages to the latest version (to be set in extra_vars) |
 
 ## Dependencies

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,6 +11,8 @@ openio_event_agent_concurrency: ""
 
 openio_event_agent_delete_workers: "1"
 openio_event_agent_delete_concurrency: "1"
+openio_event_agent_xcute_workers: "2"
+openio_event_agent_xcute_concurrency: "5"
 
 openio_event_agent_queue_url: "beanstalk://{{ openio_bind_address | d(ansible_default_ipv4.address) }}:6014"
 openio_event_agent_tube: oio
@@ -20,7 +22,7 @@ openio_event_agent_package_upgrade: "{{ openio_package_upgrade | d(false) }}"
 openio_event_agent_location: "{{ ansible_hostname }}.{{ openio_event_agent_serviceid }}"
 
 openio_event_agent_tube_delete_enabled: true
-
+openio_event_agent_tube_xcute_enabled: true
 openio_event_agent_replicator_enabled: false
 
 # pipelines

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -72,6 +72,27 @@
   when: openio_event_agent_tube_delete_enabled
   tags: configure
 
+- name: "Generate configuration files (event xcute)"
+  template:
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+    owner: openio
+    group: openio
+    mode: 0644
+  with_items:
+    - src: "event_xcute.conf.j2"
+      dest: "{{ openio_event_agent_sysconfig_dir }}/\
+        {{ openio_event_agent_servicename }}/{{ openio_event_xcute_servicename }}.conf"
+    - src: "event_xcute_handlers.conf.j2"
+      dest: "{{ openio_event_agent_sysconfig_dir }}/\
+        {{ openio_event_agent_servicename }}/oio-event-handlers-xcute.conf"
+    - src: "gridinit_event_xcute.conf.j2"
+      dest: "{{ openio_event_agent_gridinit_dir }}/{{ openio_event_agent_gridinit_file_prefix }}\
+        {{ openio_event_xcute_servicename }}.conf"
+  register: _event_xcute_conf
+  when: openio_event_agent_tube_xcute_enabled
+  tags: configure
+
 - name: "Ensure proper state for gridinit service"
   file:
     name: "{{ openio_event_agent_gridinit_dir }}/{{ openio_event_agent_gridinit_file_prefix }}\

--- a/templates/event_xcute.conf.j2
+++ b/templates/event_xcute.conf.j2
@@ -1,0 +1,14 @@
+# {{ ansible_managed }}
+[event-agent]
+tube = oio-xcute
+namespace = {{ openio_event_agent_namespace }}
+user = openio
+queue_url = {{ openio_event_agent_queue_url }}
+workers = {{ openio_event_agent_xcute_workers }}
+concurrency = {{ openio_event_agent_xcute_concurrency }}
+handlers_conf = /etc/oio/sds/{{ openio_event_agent_namespace }}/{{ openio_event_agent_servicename }}/oio-event-handlers-xcute.conf
+log_facility = LOG_LOCAL0
+log_level = info
+log_name = {{ openio_event_xcute_servicename }}
+log_address = /dev/log
+syslog_prefix = OIO,{{ openio_event_agent_namespace }},oio-event-agent,{{ openio_event_agent_serviceid }}

--- a/templates/event_xcute_handlers.conf.j2
+++ b/templates/event_xcute_handlers.conf.j2
@@ -1,0 +1,6 @@
+# {{ ansible_managed }}
+[handler:xcute.tasks]
+pipeline = xcute
+
+[filter:xcute]
+use = egg:oio#xcute

--- a/templates/gridinit_event_xcute.conf.j2
+++ b/templates/gridinit_event_xcute.conf.j2
@@ -1,0 +1,10 @@
+# {{ ansible_managed }}
+[Service.{{ openio_event_agent_namespace }}-{{ openio_event_xcute_servicename }}]
+command=/usr/bin/oio-event-agent /etc/oio/sds/{{ openio_event_agent_namespace }}/oio-event-agent-{{ openio_event_agent_serviceid }}/{{ openio_event_xcute_servicename }}.conf
+enabled=true
+start_at_boot=true
+on_die=respawn
+group={{ openio_event_agent_namespace }},oio-event-agent,{{ openio_event_agent_serviceid }}
+uid=openio
+gid=openio
+env.PATH=/usr/local/bin:/usr/bin:/usr/local/sbin:/usr/sbin

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -2,6 +2,7 @@
 openio_event_agent_sysconfig_dir: "/etc/oio/sds/{{ openio_event_agent_namespace }}"
 openio_event_agent_servicename: "oio-event-agent-{{ openio_event_agent_serviceid }}"
 openio_event_delete_servicename: "{{ openio_event_agent_servicename }}.1"
+openio_event_xcute_servicename: "{{ openio_event_agent_servicename }}.2"
 
 openio_event_agent_definition_file: >
   "{{ openio_event_agent_sysconfig_dir }}/


### PR DESCRIPTION
 ##### SUMMARY

`xcute` needs an instance of event-agent to process event in beanstallkd.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION
This instance is deployed apart to not interfere with the existing instances.