### PR TITLE
BUGFIX/MEDIUM(oio-event-agent): Install libisal during role play

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -12,4 +12,15 @@
   retries: 5
   delay: 2
   tags: install
+
+- name: Install libisal
+  package:
+    name: libisal2
+  when: ansible_architecture == 'x86_64'
+  ignore_errors: "{{ ansible_check_mode }}"
+  register: install_packages_isal
+  until: install_packages_isal is success
+  retries: 5
+  delay: 2
+  tags: install
 ...

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -12,4 +12,15 @@
   retries: 5
   delay: 2
   tags: install
+
+- name: Install libisal
+  package:
+    name: libisal
+  when: ansible_architecture == 'x86_64'
+  ignore_errors: "{{ ansible_check_mode }}"
+  register: install_packages_isal
+  until: install_packages_isal is success
+  retries: 5
+  delay: 2
+  tags: install
 ...


### PR DESCRIPTION
 ##### SUMMARY

In the 19.10 release, the event-agent loads the EC library at runtime,
which causes a failure if libisal is not present. This ensures the lib
is setup before the service starts.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION