### PR TITLE
FEATURE(event-agent): use the new replication filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ An Ansible role for oio-event-agent. Specifically, the responsibilities of this 
 | `openio_event_agent_filter_volume_index` | `dict` | Options of `volume_index` filter |
 | `openio_event_agent_filter_noop` | `dict` | Options of `noop` filter |
 | `openio_event_agent_filter_quarantine` | `dict` | Options of `quarantine` filter |
-| `openio_event_agent_filter_replication` | `dict` | Options of `replication` filter |
+| `openio_event_agent_filter_replication` | `dict` | Options of `replication` filter: `check_replication_enabled` (false), `connection_timeout` (2.0), `read_timeout` (30.0), `cache_duration` (30.0), `cache_size` (10000) |
 | `openio_event_agent_gridinit_dir` | `"/etc/gridinit.d/{{ openio_event_agent_namespace }}"` | Path to copy the gridinit conf |
 | `openio_event_agent_gridinit_file_prefix` | `""` | Maybe set it to {{ openio_ecd_namespace }}- for old gridinit's style |
 | `openio_event_agent_location` | `"{{ ansible_hostname }}.{{ openio_event_agent_serviceid }}"` | Location |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -106,9 +106,10 @@ openio_event_agent_filter_quarantine:
   queue_url: "{{ openio_event_agent_queue_url }}"
 
 openio_event_agent_filter_replication:
-  use: "egg:oio#notify"
+  use: "egg:oio#replicate"
   tube: "oio-repli"
   queue_url: "{{ openio_event_agent_queue_url }}"
+  check_replication_enabled: false
 
 openio_event_agent_filter_content_improve:
   use: "egg:oio#notify"


### PR DESCRIPTION
 ##### SUMMARY

Use the new replication filter ("replicate") which is able to check in
the account service if the replication is enabled for the container emitting
each event. In case the replication is not enabled, the event is dropped.

By default, this new behavior is disabled, and each event will be forwarded
to the replication queue. Set check_replication_enabled to true to
enable the new behavior.

These new parameters have also been implemented:
- connection_timeout: connection timeout to the account service.
- read_timeout: read timeout for the account service.
- cache_duration: how long to keep the replication state before checking
  again in the account service.
- cache_size: how many containers to keep in the cache.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION
The new filter will be available in oio-sds starting from version 5.4.0.
The old generic "notify" filter will remain available.